### PR TITLE
File url api

### DIFF
--- a/docs/advanced_topics/api/v2/configuration.rst
+++ b/docs/advanced_topics/api/v2/configuration.rst
@@ -228,6 +228,7 @@ This would add the following to the JSON:
             "meta": {
                 "type": "wagtailimages.Image",
                 "detail_url": "http://www.example.com/api/v2/images/12/",
+                "download_url": "/media/images/a_test_image.jpg",
                 "tags": []
             },
             "title": "A test image",
@@ -240,6 +241,12 @@ This would add the following to the JSON:
             "height": 100
         }
     }
+
+
+Note: ``download_url`` is the original uploaded file path, whereas
+``feed_image_thumbnail['url']`` is the url of rendered imaged.
+When you are using another storage backend, such as S3, ``download_url`` will return
+a URL to the image if your media files are properly configured.
 
 Additional settings
 ===================

--- a/wagtail/admin/tests/api/test_images.py
+++ b/wagtail/admin/tests/api/test_images.py
@@ -47,7 +47,7 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
         for image in content['items']:
             self.assertIn('meta', image)
             self.assertIsInstance(image['meta'], dict)
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
 
             # Type should always be wagtailimages.Image
             self.assertEqual(image['meta']['type'], 'wagtailimages.Image')
@@ -64,7 +64,7 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
 
     def test_fields(self):
         response = self.get_response(fields='width,height')
@@ -72,7 +72,7 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
 
     def test_remove_fields(self):
         response = self.get_response(fields='-title')
@@ -87,14 +87,14 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'download_url'})
 
     def test_remove_all_meta_fields(self):
         response = self.get_response(fields='-type,-detail_url,-tags')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'title', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image.keys()), {'id', 'title', 'width', 'height', 'thumbnail', 'meta'})
 
     def test_remove_id_field(self):
         response = self.get_response(fields='-id')
@@ -109,7 +109,7 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
 
     def test_all_fields_then_remove_something(self):
         response = self.get_response(fields='*,-title,-tags')
@@ -117,7 +117,7 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'download_url'})
 
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
@@ -125,7 +125,7 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
             self.assertIsInstance(image['meta']['tags'], list)
 
 

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -188,7 +188,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
                 self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
                 self.assertIsInstance(feed_image['id'], int)
                 self.assertIsInstance(feed_image['meta'], dict)
-                self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
+                self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url', 'download_url'})
                 self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
                 self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/%d/' % feed_image['id'])
 
@@ -496,7 +496,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title'})
         self.assertEqual(content['feed_image']['id'], 7)
         self.assertIsInstance(content['feed_image']['meta'], dict)
-        self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})
+        self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url', 'download_url'})
         self.assertEqual(content['feed_image']['meta']['type'], 'wagtailimages.Image')
         self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/7/')
 
@@ -657,7 +657,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
         self.assertIsInstance(feed_image['id'], int)
         self.assertIsInstance(feed_image['meta'], dict)
-        self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
+        self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url', 'download_url'})
         self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
         self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/%d/' % feed_image['id'])
 

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -47,7 +47,7 @@ class TestImageListing(TestCase):
         for image in content['items']:
             self.assertIn('meta', image)
             self.assertIsInstance(image['meta'], dict)
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
 
             # Type should always be wagtailimages.Image
             self.assertEqual(image['meta']['type'], 'wagtailimages.Image')
@@ -64,7 +64,7 @@ class TestImageListing(TestCase):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
 
     def test_fields(self):
         response = self.get_response(fields='width,height')
@@ -72,7 +72,7 @@ class TestImageListing(TestCase):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
 
     def test_remove_fields(self):
         response = self.get_response(fields='-title')
@@ -87,14 +87,14 @@ class TestImageListing(TestCase):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'download_url'})
 
     def test_remove_all_meta_fields(self):
         response = self.get_response(fields='-type,-detail_url,-tags')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'title'})
+            self.assertEqual(set(image.keys()), {'id', 'title', 'meta'})
 
     def test_remove_id_field(self):
         response = self.get_response(fields='-id')
@@ -109,7 +109,7 @@ class TestImageListing(TestCase):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
 
     def test_all_fields_then_remove_something(self):
         response = self.get_response(fields='*,-title,-tags')
@@ -117,7 +117,7 @@ class TestImageListing(TestCase):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'width', 'height'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'download_url'})
 
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
@@ -125,7 +125,8 @@ class TestImageListing(TestCase):
 
         for image in content['items']:
             self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
             self.assertIsInstance(image['meta']['tags'], list)
 
     def test_star_in_wrong_position_gives_error(self):

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -262,7 +262,7 @@ class TestPageListing(TestCase):
                 self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
                 self.assertIsInstance(feed_image['id'], int)
                 self.assertIsInstance(feed_image['meta'], dict)
-                self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
+                self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url', 'download_url'})
                 self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
                 self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/api/v2beta/images/%d/' % feed_image['id'])
 
@@ -851,7 +851,7 @@ class TestPageDetail(TestCase):
         self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title'})
         self.assertEqual(content['feed_image']['id'], 7)
         self.assertIsInstance(content['feed_image']['meta'], dict)
-        self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})
+        self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url', 'download_url'})
         self.assertEqual(content['feed_image']['meta']['type'], 'wagtailimages.Image')
         self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/api/v2beta/images/7/')
 
@@ -991,7 +991,7 @@ class TestPageDetail(TestCase):
         self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
         self.assertIsInstance(feed_image['id'], int)
         self.assertIsInstance(feed_image['meta'], dict)
-        self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
+        self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url', 'download_url'})
         self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
         self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/api/v2beta/images/%d/' % feed_image['id'])
 

--- a/wagtail/images/api/v2/endpoints.py
+++ b/wagtail/images/api/v2/endpoints.py
@@ -9,8 +9,8 @@ class ImagesAPIEndpoint(BaseAPIEndpoint):
     base_serializer_class = ImageSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     body_fields = BaseAPIEndpoint.body_fields + ['title', 'width', 'height']
-    meta_fields = BaseAPIEndpoint.meta_fields + ['tags']
-    listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags']
-    nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title']
+    meta_fields = BaseAPIEndpoint.meta_fields + ['tags', 'download_url']
+    listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags', 'download_url']
+    nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title', 'download_url']
     name = 'images'
     model = get_image_model()

--- a/wagtail/images/api/v2/serializers.py
+++ b/wagtail/images/api/v2/serializers.py
@@ -1,5 +1,20 @@
+from rest_framework.fields import Field
 from wagtail.api.v2.serializers import BaseSerializer
 
 
+class ImageDownloadUrlField(Field):
+    """
+    Serializes the "download_url" field for images.
+
+    Example:
+    "download_url": "/media/images/a_test_image.jpg"
+    """
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, image):
+        return image.file.url
+
+
 class ImageSerializer(BaseSerializer):
-    pass
+    download_url = ImageDownloadUrlField(read_only=True)


### PR DESCRIPTION
In addition to the (circular) `detail_url`, this adds a `download_url` to work the same way as the documents API.
